### PR TITLE
Fixed the issue improper Report class creation from JSON data

### DIFF
--- a/ak_vendor/report/report.py
+++ b/ak_vendor/report/report.py
@@ -559,10 +559,10 @@ class Report:
     is_included_dynamic_scan = attr.ib(type=bool, default=True)
     is_included_api_scan = attr.ib(type=bool, default=True)
     is_included_manual_scan = attr.ib(type=bool, default=True)
-    is_done_static_scan = attr.ib(type=bool, default=True)
-    is_done_dynamic_scan = attr.ib(type=bool, default=True)
-    is_done_api_scan = attr.ib(type=bool, default=True)
-    is_done_manual_scan = attr.ib(type=bool, default=True)
+    is_done_static_scan = attr.ib(type=bool, default=False)
+    is_done_dynamic_scan = attr.ib(type=bool, default=False)
+    is_done_api_scan = attr.ib(type=bool, default=False)
+    is_done_manual_scan = attr.ib(type=bool, default=False)
     references = attr.ib(factory=list, type=List[Reference])
     custom_meta_data = attr.ib(factory=list, type=List[CustomMetaData])
     analyses = attr.ib(factory=list, type=List[Analysis])
@@ -590,21 +590,29 @@ class Report:
             is_partnered=data.get('is_partnered'),
             rating=data.get('rating'),
             is_included_static_scan=data.get(
-                'is_included_static_scan', True),
+                'is_included_static_scan',
+                cls.__attrs_attrs__.is_included_static_scan.default),
             is_included_dynamic_scan=data.get(
-                'is_included_dynamic_scan', True),
+                'is_included_dynamic_scan',
+                cls.__attrs_attrs__.is_included_dynamic_scan.default),
             is_included_api_scan=data.get(
-                'is_included_api_scan', True),
+                'is_included_api_scan',
+                cls.__attrs_attrs__.is_included_api_scan.default),
             is_included_manual_scan=data.get(
-                'is_included_manual_scan', True),
+                'is_included_manual_scan',
+                cls.__attrs_attrs__.is_included_manual_scan.default),
             is_done_static_scan=data.get(
-                'is_done_static_scan', True),
+                'is_done_static_scan',
+                cls.__attrs_attrs__.is_done_static_scan.default),
             is_done_dynamic_scan=data.get(
-                'is_done_dynamic_scan', True),
+                'is_done_dynamic_scan',
+                cls.__attrs_attrs__.is_done_dynamic_scan.default),
             is_done_api_scan=data.get(
-                'is_done_api_scan', True),
+                'is_done_api_scan',
+                cls.__attrs_attrs__.is_done_api_scan.default),
             is_done_manual_scan=data.get(
-                'is_done_manual_scan', True),
+                'is_done_manual_scan',
+                cls.__attrs_attrs__.is_done_manual_scan.default),
             references=[
                 Reference(**reference)
                 for reference in data.get('references', [])

--- a/ak_vendor/report/report.py
+++ b/ak_vendor/report/report.py
@@ -312,6 +312,16 @@ class HIPAA:
             specifications=specifications
         )
 
+    @classmethod
+    def from_json(cls, data: dict):
+        return cls(
+            code=data.get('code'),
+            safeguard=data.get('safeguard'),
+            title=data.get('title'),
+            standards=[cls.create_standard(**standard) for standard
+                       in data.get('standards', [])],
+        )
+
     def add_standard(self, standard: HIPAAStandard) -> List[HIPAAStandard]:
         self.standards.append(standard)
         return self.standards
@@ -327,8 +337,9 @@ class Regulatory:
     def from_json(cls, data):
         return cls(
             owasp=[OWASP(**owasp) for owasp in data.get('owasp', [])],
-            pcidss=[PCIDSS(**pcidss) for pcidss in data.get('pcidss', [])],
-            hipaa=[HIPAA(**hipaa) for hipaa in data.get('hipaa', [])],
+            pcidss=[PCIDSS(**pcidss) for pcidss
+                    in data.get('pcidss', [])],
+            hipaa=[HIPAA.from_json(hipaa) for hipaa in data.get('hipaa', [])],
         )
 
     @classmethod

--- a/ak_vendor/report/report.py
+++ b/ak_vendor/report/report.py
@@ -589,6 +589,22 @@ class Report:
             show_copyright=data.get('show_copyright'),
             is_partnered=data.get('is_partnered'),
             rating=data.get('rating'),
+            is_included_static_scan=data.get(
+                'is_included_static_scan', True),
+            is_included_dynamic_scan=data.get(
+                'is_included_dynamic_scan', True),
+            is_included_api_scan=data.get(
+                'is_included_api_scan', True),
+            is_included_manual_scan=data.get(
+                'is_included_manual_scan', True),
+            is_done_static_scan=data.get(
+                'is_done_static_scan', True),
+            is_done_dynamic_scan=data.get(
+                'is_done_dynamic_scan', True),
+            is_done_api_scan=data.get(
+                'is_done_api_scan', True),
+            is_done_manual_scan=data.get(
+                'is_done_manual_scan', True),
             references=[
                 Reference(**reference)
                 for reference in data.get('references', [])


### PR DESCRIPTION
Issue:

1. The `from_json` method on `Regulatory` class inside `report.py` was creating  `HIPAA` class in such a way that the `standards` field of the `HIPAA` class was being set to a list of dictionaries instead of a list of `HIPAAStandard`.

Fix:
- Added `from_json` method on `HIPAA` class which will take care of creation of `HIPAAStandard`.
- The `from_json` method on `Regulatory` class will now call `HIPAA.from_json`.

2. The `from_json` method on `Report` class was not setting the value of following fields:
- is_included_static_scan
- is_included_dynamic_scan
- is_included_api_scan
- is_included_manual_scan
- is_done_static_scan
- is_done_dynamic_scan
- is_done_api_scan
- is_done_manual_scan

Fix:
- Modified `from_json` method on `Report` class to fixed second issue.