### PR TITLE
PD-631 hide manual scan status from report

### DIFF
--- a/ak_vendor/report/report.py
+++ b/ak_vendor/report/report.py
@@ -2,6 +2,7 @@ import attr
 import enum
 import maya
 import json
+import typing
 import html2text
 from datetime import datetime
 from urllib.parse import quote
@@ -569,6 +570,10 @@ class Analysis:
 
 
 @attr.s
+class OrganizationFeature:
+    manualscan = attr.ib(type=bool, default=False)
+
+@attr.s
 class Report:
     COLOR_CRITICAL = RiskColorEnum.CRITICAL.value
     COLOR_HIGH = RiskColorEnum.HIGH.value
@@ -587,6 +592,7 @@ class Report:
     package_name = attr.ib(type=str)
     platform = attr.ib(type=Platform)
     application = attr.ib(type=Application)
+    features = attr.ib(type=OrganizationFeature)
     appknox_file_id = attr.ib(type=int, default=None)
     prepared_for = attr.ib(type=Company, default=Company(name=""))
     prepared_by = attr.ib(
@@ -633,6 +639,7 @@ class Report:
             show_copyright=data.get("show_copyright"),
             is_partnered=data.get("is_partnered"),
             rating=data.get("rating"),
+            features=OrganizationFeature(**data.get("features")),
             is_included_static_scan=data.get(
                 "is_included_static_scan",
                 cls.__attrs_attrs__.is_included_static_scan.default,
@@ -773,6 +780,10 @@ class Report:
     @classmethod
     def parse_cvssv3_vector(cls, **kwargs) -> CVSSv3:
         return CVSSv3.parse_vector(**kwargs)
+
+    @classmethod
+    def create_features(cls, **kwargs) -> "OrganizationFeature":
+        return OrganizationFeature(**kwargs)
 
     @classmethod
     def get_risk_color(cls, risk: str) -> str:

--- a/ak_vendor/templates/report_template.html
+++ b/ak_vendor/templates/report_template.html
@@ -617,7 +617,7 @@
             {% endif %}
             <span>{% trans "API" %}</span>
           </span>
-          {% if report.is_included_manual_scan %}
+          {% if report.features.manualscan %}
             <span class="scan__type">
               {% if report.is_done_manual_scan %}
                   <img class="scan__type__icon" src="{{ icon_done }}"></img>

--- a/ak_vendor/templates/report_template.html
+++ b/ak_vendor/templates/report_template.html
@@ -617,14 +617,16 @@
             {% endif %}
             <span>{% trans "API" %}</span>
           </span>
-          <span class="scan__type">
-            {% if report.is_done_manual_scan %}
-                <img class="scan__type__icon" src="{{ icon_done }}"></img>
-            {% else %}
-                <img class="scan__type__icon" src="{{ icon_not_done }}"></img>
-            {% endif %}
-            <span>{% trans "Manual" %}</span>
-          </span>
+          {% if report.is_included_manual_scan %}
+            <span class="scan__type">
+              {% if report.is_done_manual_scan %}
+                  <img class="scan__type__icon" src="{{ icon_done }}"></img>
+              {% else %}
+                  <img class="scan__type__icon" src="{{ icon_not_done }}"></img>
+              {% endif %}
+              <span>{% trans "Manual" %}</span>
+            </span>
+          {% endif %}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
2. Added `feature` field in the `Report` class.
3. Based on the value of `manualscan` field of `features`, the `Manual` scan type will be shown in the `Scan Status` field of the `Audit Details` in the report.